### PR TITLE
Finished fix testLoadConfigWithMissingValues() flaky

### DIFF
--- a/src/test/java/de/henne90gen/chestcounter/FileChestDBTest.java
+++ b/src/test/java/de/henne90gen/chestcounter/FileChestDBTest.java
@@ -11,6 +11,7 @@ import java.io.*;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.Arrays;
 
 import static org.junit.Assert.*;
 
@@ -309,8 +310,10 @@ public class FileChestDBTest {
                     "\"version\":" + ChestStorage.CURRENT_VERSION + "," +
                     "\"config\":{\"enabled\":true,\"showSearchResultInInventory\":true,\"showSearchResultInGame\":true,\"searchResultPlacement\":\"" + SearchResultPlacement.RIGHT_OF_INVENTORY + "\"}," +
                     "\"worlds\":{}}";
+            String sortedExpectedLine = sortFileLines(expectedLine);
             assertEquals(1, lines.size());
-            assertEquals(expectedLine, lines.get(0));
+            String sortedLines = sortFileLines(lines.get(0));
+            assertEquals(sortedExpectedLine, sortedLines);
         }
         new File(filename).delete();
     }
@@ -359,5 +362,23 @@ public class FileChestDBTest {
                     + chestID
                     + "\":{\"items\":{\"" + itemName + "\":" + itemAmount + "},\"label\":\"" + chestLabel + "\"}}}}");
         }
+    }
+
+    private String sortFileLines(String input) {
+        String inputFields = input.substring(1, input.length() - 1);
+        int configIdx = inputFields.indexOf("\"config");
+        String configRaw = inputFields.substring(configIdx);
+        int configStart = configRaw.indexOf("{");
+        int configEnd = configRaw.indexOf("}");
+        String configString = configRaw.substring(configStart + 1, configEnd);
+        String[] configArr = configString.split(",");
+        Arrays.sort(configArr);
+        String sortedConfigString = "\"config\":{" + String.join(".", configArr) + "}";
+        String newInputFields = inputFields.substring(0, configIdx) + sortedConfigString + configRaw.substring(configEnd + 1);
+        System.out.println("New Input: " + newInputFields);
+        String[] outsideList = newInputFields.split(",");
+        Arrays.sort(outsideList);
+        String ans = "{" + String.join(",", outsideList) + "}";
+        return ans;
     }
 }


### PR DESCRIPTION
## Changes proposed
Test```de.henne90gen.chestcounter.FileChestDBTest.testLoadConfigWithMissingValues``` was found flaky by an open-source research tool [NonDex](https://github.com/TestingResearchIllinois/NonDex), which will shuffle implementation-dependent operations. The flakiness was resulted from the indetermined order of the fields inside the file lines generated by calling ```reader.lines().collect(Collectors.toList());``` . The  string ```expectedLine``` used in the unit test was defined using a pattern with fixed order, and it will not match the ```lines.get(0);``` generated lines during shuffling; thus, the test will fail. The error messages: 
```
de.henne90gen.chestcounter.FileChestDBTest > testLoadConfigWithMissingValues FAILED
    org.junit.ComparisonFailure: expected:<{"[version":3,"config":{"enabled":true,"showSearchResultInInventory":true,"showSearchResultInGame":true,"searchResultPlacement":"RIGHT_OF_INVENTORY"},"worlds":{}]}> but was:<{"[config":{"showSearchResultInGame":true,"showSearchResultInInventory":true,"searchResultPlacement":"RIGHT_OF_INVENTORY","enabled":true},"worlds":{},"version":3]}>
        at org.junit.Assert.assertEquals(Assert.java:115)
        at org.junit.Assert.assertEquals(Assert.java:144)
        at de.henne90gen.chestcounter.FileChestDBTest.testLoadConfigWithMissingValues(FileChestDBTest.java:318)
```

## Fix of the problem
Since the file lines for test input was generated by Java default package, no changes can be made to that package. I therefore sorted the fields inside the file lines alphabetically. This involves in a lot of substring operations because those fields were embeded in curly braces separated by ",". I sorted the config body in the lines first and then recombined the string and sorted again to generate the final answer. Finally, instead of comparing the original ```expectLine``` and ```lines.get(0)```, I compared the ```sortedExpectedLine``` and ```sortedFileLines``` for testing.

## Result of the fix
The test successed with Nondex runs for 3, 10, and 100 times. It can be safely concluded that the flakiness of this test is fixed

## Test Environment:
```
openjdk version "11.0.20.1"
Gradle 7.2
Ubuntu 20.04.6 LTS
Linux version: 5.4.0-163-generic
```